### PR TITLE
add new pow_to_pexpr rule

### DIFF
--- a/src/mathematica.lean
+++ b/src/mathematica.lean
@@ -484,6 +484,11 @@ meta def mul_to_pexpr : app_trans_pexpr_keyed_rule :=
 λ env args, do args' ← monad.mapm (pexpr_of_mmexpr env) args, return $ pexpr_fold_op ```(1) ```(has_mul.mul) args'⟩
 
 @[app_to_pexpr_keyed]
+meta def pow_to_pexpr : app_trans_pexpr_keyed_rule :=
+⟨"Power",
+λ env args, do args' ← monad.mapm (pexpr_of_mmexpr env) args, return $ pexpr_fold_op ```(1) ```(has_pow.pow) args'⟩
+
+@[app_to_pexpr_keyed]
 meta def list_to_pexpr : app_trans_pexpr_keyed_rule :=
 ⟨"List", λ env args,
          do args' ← monad.mapm (pexpr_of_mmexpr env) args,


### PR DESCRIPTION
I found that I needed a `pow_to_pexpr` to complete the translation of

``` wolfram
ProveUsingLeanTactic[
ForAllTyped[{x, y}, real, Equal[Hold[Power[x + y, 2]], Hold[x ^ 2 + 2 * x * y + y ^ 2]]],
"`[mm_prover]", LeanExecutable, True]
```

->

```lean
"AY[ForAllTyped][AY[List][Y[x],Y[y]],Y[real],AY[Equal][AY[Hold][AY[Power][AY[Plus][Y[x],Y[y]],I[2]]],AY[Hold][AY[Plus][AY[Power][Y[x],I[2]],AY[Times][I[2],Y[x],Y[y]],AY[Power][Y[y],I[2]]]]]]"
```

->

``` lean
∀ (x y : ℝ), (x + y) ^ 2 = x ^ 2 + 2 * x * y + y ^ 2
```

